### PR TITLE
feat(skills): sync batteries skills from dev1, add auto-debug and research

### DIFF
--- a/batteries/kata.yaml
+++ b/batteries/kata.yaml
@@ -80,8 +80,8 @@ modes:
     description: "Execute approved specs"
     rules:
       - "You are an IMPLEMENTATION ORCHESTRATOR. Coordinate agents to execute the approved spec."
-      - "Spawn impl-agents for code work (Agent tool with subagent_type=impl-agent) — do NOT write implementation code yourself."
-      - "Run quality gates after each phase: build, typecheck, tests (TEST protocol), then review (REVIEW protocol)."
+      - "Invoke /code-impl skill for implementation work — spawn impl-agents for each unit of work, verify via gate."
+      - "Run quality gates after each phase: build, typecheck, tests (/test-protocol), then review (/code-review)."
       - "One spec phase at a time. Complete IMPL + TEST + REVIEW before moving to the next phase."
       - "Read the spec first — understand ALL phases before writing any code. Spec non-goals are off-limits."
     issue_handling: "required"

--- a/batteries/skills/auto-debug/SKILL.md
+++ b/batteries/skills/auto-debug/SKILL.md
@@ -1,0 +1,112 @@
+---
+description: "Batch bug triage and auto-fix — classify, assess via agents, fix via agents, escalate complex ones."
+context: inline
+---
+
+# Auto-Debug Methodology
+
+You are the auto-debug orchestrator. You triage and classify, then delegate all investigation and fixes to agents.
+
+## Triage Classification
+
+For each bug, classify by surface signals:
+
+| Category | Signals | Action |
+|----------|---------|--------|
+| **auto-fixable** | Clear error, single domain, specific component | Attempt fix |
+| **needs-architecture** | Cross-worker, schema change, multiple systems | Escalate |
+| **needs-info** | Vague description, no repro steps | Skip, comment asking for info |
+| **cluster** | 3+ bugs mention same component/file/pattern | Group for architecture review |
+
+### Cluster Detection
+
+If 3+ bugs reference the same file/component, error pattern, or domain label — mark the entire cluster as **needs-architecture**. Systemic problems need specs, not band-aids.
+
+## Assessment Protocol
+
+For each auto-fixable bug, spawn a debug-agent to assess:
+
+```
+Agent(subagent_type="debug-agent", prompt="
+  Assess bug #{issue_number}: {title}
+  Description: {body}
+  Investigate root cause. Report:
+  - ROOT_CAUSE: file:line — description
+  - FIX_SCOPE: N files, ~N lines
+  - COMPLEXITY: simple | moderate | complex
+  - ESCALATION_TRIGGERS: list any that apply, or 'none'
+")
+```
+
+Run assessment agents in parallel (up to 5 concurrent).
+
+## Escalation Criteria ("Too Wiley" Gate)
+
+If ANY of these trigger, revert the fix and escalate:
+
+| # | Criterion | Threshold |
+|---|-----------|-----------|
+| 1 | Needs database migration | Any |
+| 2 | Spans 2+ workers | Any |
+| 3 | Net-new code | > 50 lines |
+| 4 | Files touched | > 4 files |
+| 5 | Actually a missing feature | Not a bug |
+| 6 | Cluster root cause | 3+ bugs same cause |
+| 7 | Changes shared abstraction | Any |
+| 8 | Third-party dependency | Any |
+| 9 | Needs new API endpoint | Any |
+| 10 | Cannot reproduce locally | Any |
+
+## Fix Loop
+
+For each approved bug, in priority order, spawn an impl-agent:
+
+```
+Agent(subagent_type="impl-agent", prompt="
+  Fix bug #{issue_number}: {title}
+  Root cause: {file:line} — {description from assessment}
+  Requirements:
+  - Minimal change, no refactoring, follow existing patterns
+  - Add regression test that reproduces the original bug
+  - If any escalation trigger fires, STOP and report back (do not commit)
+  - After fixing, run: {build_command} && {test_command}
+  - Commit with: fix({scope}): {description}
+")
+```
+
+Before spawning fix agent: `pnpm bgh claim {issue_number}`
+
+**One agent per bug, one commit per bug** — enables clean reverts if needed.
+
+## Post-Fix Validation
+
+After all fix agents complete, run the full test suite. If new failures:
+- Identify which fix caused the regression
+- Revert that commit
+- Move bug to escalation list
+- Re-run tests to confirm clean
+
+## Escalation Report
+
+Group escalated bugs by shared root cause:
+- **Cluster:** name the pattern, list related bugs, suggest fix approach
+- **Standalone:** explain why it can't be auto-fixed
+
+Comment analysis on each escalated issue with root cause and suggested approach.
+
+## Summary Format
+
+| Category | Count | Details |
+|----------|-------|---------|
+| Fixed | N | list with commit SHAs |
+| Escalated | N | list with escalation trigger |
+| Skipped | N | list with reason |
+
+## Principles
+
+- **Never fix code yourself** — spawn debug-agents to assess, impl-agents to fix
+- **Fix or escalate, never force** — if it's hard, it needs a spec
+- **One agent per bug** — parallel, independent, clean reverts
+- **Claim before fixing** — issue tracking stays accurate
+- **Cluster detection** — systemic problems get flagged, not band-aided
+- **Test after all fixes** — catch cross-bug regressions

--- a/batteries/skills/code-impl/SKILL.md
+++ b/batteries/skills/code-impl/SKILL.md
@@ -1,30 +1,66 @@
 ---
-description: "Implementation methodology — read before writing, smallest change possible, follow existing patterns, test after each change."
+description: "Implementation methodology — orchestrator reads spec, spawns impl-agents for each unit of work, verifies via gate."
 context: inline
 ---
 
 # Code Implementation
 
-## Before Writing Code
-1. **Read the spec phase** — understand exactly what to build
-2. **Check implementation hints** — correct imports, patterns, gotchas
-3. **Identify files to change** — minimize blast radius
+You are the implementation orchestrator. You do NOT write code directly — you spawn task agents to do the work, then verify the results.
 
-## While Writing Code
-1. **Follow existing patterns** — match the codebase style
-2. **Make minimal changes** — no unrelated refactoring
-3. **Run build after significant edits** — catch errors early
-4. **Run tests frequently** — don't accumulate failures
+## Protocol
 
-## After Writing Code
-1. **Review your diff** — `git diff` to verify changes are correct
-2. **Run full test suite** — ensure no regressions
-3. **Check spec compliance** — does your code match all acceptance criteria?
+### 1. Read the spec phase
 
-## Key Rules
+Read the full spec. Identify the phase you're implementing. Understand:
+- Behaviors to implement (by ID)
+- Acceptance criteria
+- Implementation hints (correct imports, patterns, gotchas)
+- Files likely to change
 
-- **Read files before editing** — never edit a file you haven't fully read
+### 2. Decompose into work units
+
+Break the spec phase into discrete units of work. Each unit should be:
+- Small enough for one agent to complete (1-3 files changed)
+- Independent or clearly ordered
+- Testable in isolation when possible
+
+### 3. Spawn impl-agents
+
+For each work unit, spawn a task agent using the Agent tool:
+
+```
+Agent(subagent_type="impl-agent", prompt="
+  Implement [specific behavior/change].
+  Spec: [relevant section or behavior IDs]
+  Files to modify: [list]
+  Acceptance criteria: [from spec]
+  After implementation, run: {build_command}
+")
+```
+
+Key rules for agent prompts:
+- **Be specific** — include file paths, behavior IDs, exact requirements
+- **Include the spec context** — don't make the agent re-discover what you already know
+- **Include build/test commands** — agent should verify its own work
+- **One concern per agent** — don't bundle unrelated changes
+
+### 4. Run agents sequentially or in parallel
+
+- Independent work units → spawn agents in parallel
+- Dependent work units → spawn sequentially, pass prior results as context
+- After each agent completes, verify its output makes sense before proceeding
+
+### 5. Verify via gate
+
+After all agents complete, the phase gate runs `{typecheck_command} && {test_command}`. If the gate fails:
+- Read the error output
+- Spawn a fix agent targeting the specific failure
+- Max 3 fix attempts before escalating to user
+
+## Rules
+
+- **Never write code yourself** — always delegate to impl-agents
+- **Read files before delegating** — understand the codebase so your agent prompts are precise
+- **Follow existing patterns** — tell agents to match codebase style
 - **Minimal scope** — implement exactly what the spec says, nothing more
-- **No gold plating** — don't add features, refactoring, or improvements beyond scope
-- **Follow existing patterns** — find similar code and match the style
-- **Typecheck after each significant edit** — catch errors early
+- **No gold plating** — don't tell agents to add features, refactoring, or improvements beyond scope

--- a/batteries/skills/code-review/SKILL.md
+++ b/batteries/skills/code-review/SKILL.md
@@ -1,27 +1,90 @@
 ---
-description: "Code review methodology — check diff against spec, verify correctness, report issues with file:line references."
-context: fork
+description: "Code review with external review agent, fix loop via task agents, and re-review until passing."
+context: inline
 ---
 
-# Code Review Methodology
+# Code Review
 
-## Review Checklist
+You are running a review-fix loop on the implementation from P1. The goal is clean, correct code that passes review with no critical or important issues.
 
-1. **Spec compliance** — does the diff implement what the spec requires?
-2. **Correctness** — are there logic errors, off-by-one mistakes, or missing edge cases?
-3. **Security** — any injection risks, exposed secrets, or OWASP top 10 issues?
-4. **Performance** — any N+1 queries, unnecessary iterations, or missing indexes?
-5. **Tests** — do tests cover the new behavior? Are assertions meaningful?
+## Protocol
 
-## Report Format
+### 1. Run the external review agent
 
-For each issue found:
-- **File:line** — exact location
-- **Severity** — critical / important / minor
-- **Issue** — what's wrong
-- **Suggestion** — how to fix
+Spawn the review agent via Bash:
 
-## Verdict
+```bash
+kata review --prompt=code-review
+```
 
-- **APPROVE** — no critical or important issues
-- **REQUEST CHANGES** — critical or important issues must be addressed
+This runs an independent agent that reads the diff against main and produces a scored assessment with categorized issues.
+
+### 2. Read the review output
+
+The review agent outputs:
+- **Verdict:** APPROVE or REQUEST_CHANGES
+- **Issues:** categorized as Critical, Important, Minor
+- **File:line** references for each issue
+
+### 3. Fix loop
+
+If REQUEST_CHANGES:
+
+1. Group related issues by file or concern
+2. For each group, spawn a task agent to fix:
+
+```
+Agent(subagent_type="impl-agent", prompt="
+  Fix review issues in [file(s)]:
+  - [Issue 1]: [description] at [file:line]
+  - [Issue 2]: [description] at [file:line]
+  After fixing, run: {build_command} && {test_command}
+")
+```
+
+3. **Minor** issues — spawn a single agent for all trivial fixes, skip cosmetic ones
+4. After all fix agents complete, run `{build_command} && {test_command}`
+5. Re-run `kata review --prompt=code-review`
+6. Repeat until verdict is APPROVE
+
+### 4. Max iterations
+
+Cap at 3 review-fix cycles. If still REQUEST_CHANGES after 3 rounds:
+- Document remaining issues
+- Ask the user whether to approve with known gaps or continue fixing
+
+## What the review checks
+
+### Spec compliance
+- Does the diff implement what the spec requires?
+- Are all behaviors from spec phases addressed?
+- No extra scope beyond spec
+
+### Correctness
+- Logic errors, off-by-one, missing edge cases
+- Race conditions, null handling, error paths
+- Type safety — no unsafe casts or `any` escapes
+
+### Security
+- Injection risks (SQL, XSS, command)
+- Exposed secrets or credentials
+- OWASP top 10 awareness
+
+### Performance
+- N+1 queries, unnecessary iterations
+- Missing indexes for new queries
+- Unbounded data fetching
+
+### Tests
+- New behavior has test coverage
+- Assertions are meaningful (not just `toBeTruthy`)
+- Edge cases tested
+
+## Rules
+
+- **Never fix code yourself** — spawn impl-agents for all fixes
+- **Don't just report — delegate fixes.** The review agent reports, you spawn agents to fix.
+- **Be specific in agent prompts** — include file:line, issue description, and expected fix
+- **Don't weaken code to pass** — if a test is failing, fix the code, not the test
+- **Don't expand scope** — review fixes only, no refactoring or feature additions
+- **Run build+tests after every fix round** — don't accumulate breakage

--- a/batteries/skills/debug-methodology/SKILL.md
+++ b/batteries/skills/debug-methodology/SKILL.md
@@ -1,9 +1,11 @@
 ---
-description: "Systematic hypothesis-driven debugging — reproduce, form hypotheses, trace systematically, minimal fix."
+description: "Systematic hypothesis-driven debugging — reproduce, form hypotheses, trace via agents, fix via agents, minimal change."
 context: inline
 ---
 
 # Debug Methodology
+
+You are the debug orchestrator. You investigate to understand the problem, then delegate all code changes to agents.
 
 ## Step 1: Reproduce
 - Capture exact reproduction steps
@@ -34,21 +36,51 @@ Before reading code, draw the system map:
 3. **Unlikely but worth checking:** {hypothesis}
 
 ## Step 5: Trace and Confirm
-- Start from the entry point (API route, UI event, job trigger)
-- Follow through all layers
-- Find where actual diverges from expected
-- Document: file:line of the root cause
+
+Spawn debug-agents to investigate each hypothesis in parallel:
+
+```
+Agent(subagent_type="debug-agent", prompt="
+  Investigate hypothesis: {hypothesis}
+  Start from: {entry point — API route, UI event, job trigger}
+  Trace through: {layers}
+  Look for: where actual diverges from expected
+  Report: file:line of root cause, or rule out this hypothesis
+")
+```
+
+- Run up to 3 agents in parallel (one per hypothesis)
+- Each agent traces one hypothesis independently
+- Consolidate findings: identify confirmed root cause with file:line
 
 ## Step 6: Fix
-- Minimal change to fix the root cause
-- Add regression test/guard
-- Verify the original bug is resolved
-- Check for regressions in related code paths
+
+Spawn an impl-agent to apply the minimal fix:
+
+```
+Agent(subagent_type="impl-agent", prompt="
+  Fix bug: {description}
+  Root cause: {file:line} — {explanation}
+  Fix: {specific change to make}
+  Also: add a regression test that reproduces the original bug
+  After fixing, run: {build_command} && {test_command}
+")
+```
+
+If the fix is multi-part (e.g., fix + migration + test), spawn one agent per concern.
+
+## Step 7: Verify
+
+After the fix agent completes:
+- Reproduce the original bug — confirm it's resolved
+- Run full test suite — confirm no regressions
+- If regressions: spawn another impl-agent targeting the specific failure
 
 ## Rules
 
 - **Reproduce first** — never fix what you haven't reproduced
 - **Map before reading** — understand the system before diving into code
 - **Three hypotheses** — don't anchor on the first idea
+- **Never write code yourself** — spawn debug-agents to trace, impl-agents to fix
 - **Minimal fix** — fix the root cause, not symptoms
-- **Regression guard** — leave a test so it can't come back silently
+- **Regression guard** — every fix includes a test

--- a/batteries/skills/interview/SKILL.md
+++ b/batteries/skills/interview/SKILL.md
@@ -1,24 +1,34 @@
 ---
-description: "Structured interview methodology — walk the decision tree one branch at a time, recommend answers, resolve from codebase when possible."
+description: "Deep requirements interview — exhaust the decision tree, bring full domain expertise, surface the non-obvious, produce spec-ready decisions."
 context: inline
 ---
 
 # Interview Methodology
 
-You are conducting a requirements interview for a feature spec. Your goal is to reach shared understanding on every decision that affects implementation — relentlessly, one question at a time.
+You are the sole human touchpoint in the specification process. Everything after this — spec writing, review, implementation — runs without the user. This interview must extract every decision, surface every tension, and resolve every ambiguity. Default to depth. Be exhaustive. Be opinionated. Be rigorous.
+
+## Mindset
+
+You are not a passive question-asker. You are a domain expert, systems architect, and product thinker rolled into one. For every question:
+
+- **Bring your full knowledge** of the domain, framework, language, and architecture pattern at play. If the feature involves real-time collaboration, think CRDTs vs OT vs last-write-wins. If it's a permissions system, think RBAC vs ABAC vs capability-based. If it's a data pipeline, think backpressure, idempotency, exactly-once semantics. Name the real concepts. Surface the real trade-offs.
+- **Recommend with conviction.** Don't present a menu — present your recommendation with reasoning, then offer alternatives. "I'd go with optimistic locking here because your write frequency is low and conflict resolution UX is simpler. The alternative is CRDTs but that's overkill for this use case because..."
+- **Go deep on what matters.** A permissions question isn't "who can do what?" — it's "what's your trust model? Are permissions inherited? Can they be delegated? What happens at the boundary between org admin and project member? What's the revocation story?"
+- **Surface the non-obvious.** The user knows what they want to build. Your job is to surface what they haven't considered — the cache invalidation problem, the N+1 query lurking in the happy path, the race condition when two users hit submit, the migration path from v1 to v2.
 
 ## Context Check
 
-Before starting, check if research findings already exist — the user may have provided a research file in their prompt or a prior research session may have produced one (check `planning/research/`). If findings exist, read them first and use them to seed your decision tree. If not, you're working from the GitHub issue and codebase alone.
+Before starting, check if research findings already exist — the user may have provided a research file in their prompt or a prior research session may have produced one (check `{research_path}/`). If findings exist, read them first and use them to seed your decision tree. If not, you're working from the GitHub issue and codebase alone.
 
 ## Core Protocol
 
 ### 1. Build the decision tree first
 
-Before asking anything, identify the decision tree for this feature:
-- What are the top-level decisions? (scope, data model, UX flow, integration points)
-- Which decisions depend on others? (e.g., error handling depends on knowing the integration points)
-- Order questions so dependencies resolve before dependents
+Before asking anything, map the full decision space for this feature:
+- What are the top-level architectural decisions? (data model, state management, API design, integration boundaries)
+- What are the product decisions? (scope, UX flow, error philosophy, migration strategy)
+- Which decisions constrain others? (data model shapes API shapes UI; auth model shapes everything)
+- Order questions so foundations resolve before dependents
 - If research findings exist, many branches may already be partially resolved — focus on what's still open
 
 ### 2. Use AskUserQuestion
@@ -33,17 +43,19 @@ Each question needs:
 - `options` — 2-4 concrete choices with descriptions (user can always pick "Other")
 - `multiSelect: true` when choices aren't mutually exclusive (e.g., "Which test types?")
 
-Put your **recommended option first** and add "(Recommended)" to its label. Use `preview` on options when showing code snippets or mockups the user needs to compare.
+Put your **recommended option first** and add "(Recommended)" to its label. Use `preview` on options when showing code snippets, architecture diagrams, or data model shapes the user needs to compare.
 
-### 3. Recommend an answer
+Option descriptions should demonstrate expertise — not "Simple approach" but "Last-write-wins with timestamp — no conflict UI needed, acceptable when concurrent edits are rare (<1% of writes)."
 
-For every question, provide your recommended answer based on:
-- What you learned from codebase research (P0)
-- Existing patterns in the project
-- Common best practices
-- Prior answers in this interview
+### 3. Recommend with depth
 
-Format: state the question, then "**Recommended:** {your recommendation and why}". Give concrete options when possible.
+For every question, lead with your recommendation and the reasoning chain behind it:
+- What you learned from codebase research — existing patterns, conventions, constraints
+- Domain best practices — name the pattern, explain why it fits HERE specifically
+- Trade-off analysis — what you gain, what you give up, when this choice would be wrong
+- Prior answers in this interview — how this connects to decisions already made
+
+Don't just say "I recommend X." Say "I recommend X because your data model has Y constraint, your team already uses Z pattern in the auth module, and the alternative W would require a migration that doesn't pay off until you hit scale N."
 
 ### 4. Codebase-first resolution
 
@@ -51,67 +63,93 @@ If a question can be answered by exploring the codebase, **explore instead of as
 - "Which components exist for this?" — Glob/Grep for them, present findings
 - "What's the current data model?" — read the schema, summarize it
 - "How does the similar feature X work?" — read the code, explain it
+- "What's the auth pattern?" — read the middleware, explain the trust boundaries
 
-Only ask the user when the answer requires a product decision, not a fact lookup.
+Only ask the user when the answer requires a product decision, not a fact lookup. Every question you don't need to ask is time saved for deeper questions you DO need to ask.
 
-### 5. Listen for implicit requirements
+### 5. User-triggered research
+
+When the user responds with signals like "need more research", "check the docs", "find options", "what are the alternatives", "look into X" — pause the interview and spawn research:
+
+- **Codebase questions** — spawn an Explore agent to investigate, then return with findings
+- **External docs/libraries** — use WebSearch + WebFetch to find docs, comparisons, benchmarks
+- **Architecture options** — research the named patterns, summarize trade-offs, then resume with an informed recommendation
+
+Don't ask for permission to research — if the user says "check", check. Come back with findings and a revised recommendation, then continue the interview.
+
+### 6. Listen for implicit requirements
 
 Users reveal constraints in passing ("oh and it needs to work offline", "we're migrating off that soon"). When you hear one:
 - Pause the current branch
 - Confirm: "I heard {implicit requirement} — is that a hard constraint?"
 - If yes, add it to the decision tree (it may create new branches)
+- Trace the implications — an offhand "needs to work offline" might reshape your entire state management and sync strategy
 
-### 6. Confirm understanding before moving on
 
-After each answer, restate what you understood in one sentence. Don't move to the next question until confirmed.
+## Interview Depth by Category
 
-## Interview Categories
-
-Work through these categories in order. Skip categories that don't apply (e.g., skip Design for backend-only features). Within each category, follow the decision tree — don't just go down the list linearly.
+Work through these categories in order. Skip categories that don't apply. Within each category, follow the decision tree — don't just go down the list linearly. **Go as deep as the feature demands.** A CRUD form needs less depth than a real-time collaboration engine.
 
 ### Requirements
-Resolve: problem statement -> happy path -> scope boundaries -> edge cases
-- What user problem does this solve? What's the trigger?
-- Walk me through the ideal success flow step by step
-- What's explicitly NOT being built? (non-goals)
-- Edge cases: empty state, first-time use, error recovery
-- Scale: expected data volume? (affects pagination, caching, indexing)
-- Concurrency: multiple users editing simultaneously?
+Resolve: problem statement -> user mental model -> happy path -> scope boundaries -> edge cases -> failure modes
+
+- What user problem does this solve? What's the trigger? What's the user's mental model of how this should work?
+- Walk me through the ideal success flow step by step — every screen, every click, every state transition
+- What's explicitly NOT being built? (non-goals) — be aggressive here, scope creep kills specs
+- Edge cases that matter for THIS specific feature type:
+  - Empty/zero state, first-time use, onboarding
+  - Error recovery — what happens when it fails halfway?
+  - Data migration — what happens to existing data?
+  - Backwards compatibility — does this break anything?
+- Scale: expected data volume, growth trajectory, hot spots
+- Concurrency: who else is touching this data? What's the conflict model?
 
 ### Architecture
-Resolve: integration points -> data flow -> error handling -> performance
-- Which existing systems/APIs does this touch?
-- What's the data flow? (user action -> API -> DB -> response)
-- How should errors surface? (inline, toast, error page, silent retry)
-- Any latency or throughput constraints?
-- Auth/permissions: who can do what?
+Resolve: system boundaries -> data model -> API contract -> state management -> error philosophy -> performance envelope
+
+- System boundaries — what's in-process, what's a service call, what's eventual consistency?
+- Data model — entities, relationships, ownership, lifecycle. Get the nouns right.
+- API design — REST/GraphQL/RPC? Pagination strategy? Versioning? Rate limiting?
+- State management — server-authoritative, client-optimistic, CRDT, event-sourced? Pick the right tool.
+- Error philosophy — fail fast vs degrade gracefully vs retry? Per-operation, not blanket.
+- Performance — what's the latency budget? Where are the N+1 queries? What needs caching?
+- Auth/permissions — trust model, permission granularity, inheritance, delegation, revocation
+- Observability — what metrics matter? What alerts? What's the debugging story?
 
 ### Testing
-Resolve: happy path verification -> error scenarios -> test types
-- What scenarios prove this feature works?
-- What should fail gracefully? (validation, permissions, network)
-- Unit, integration, or e2e? (pick based on what the feature actually needs)
+Resolve: confidence model -> critical paths -> test boundaries -> verification strategy
+
+- What gives you confidence this works? What's the one test that, if it passes, you'd ship?
+- Critical error paths — not "validation errors" generically, but the specific failures that would wake someone up at 3am
+- Test boundaries — what's unit-testable, what needs integration, what needs e2e?
+- Data fixtures — what test data setup does this require?
 
 ### Design (UI features only)
-Resolve: reference patterns -> layout -> components -> states
-- Which existing page is most similar?
-- What layout pattern fits? (list, detail, form, dashboard)
-- Which existing components can be reused?
-- Visual states: loading, empty, error, success?
+Resolve: information architecture -> interaction model -> component composition -> state choreography
+
+- Information architecture — what's the hierarchy? What's primary vs secondary vs tertiary?
+- Interaction model — direct manipulation, form-based, wizard, conversational?
+- Component composition — reuse existing or create new? What's the component boundary?
+- State choreography — loading, empty, error, success, partial, stale. Every state the user can see.
+- Accessibility — keyboard nav, screen readers, color contrast, motion sensitivity
+- Responsive — does it need to work on mobile? Tablet? What breaks at narrow viewports?
 
 ## Completion
 
 When all branches of the decision tree are resolved:
-1. Produce a **Requirements Summary** — structured list of every decision made, grouped by category
-2. Call out any **Open Risks** — decisions where the user was uncertain or where you see potential issues
+1. Produce a **Requirements Summary** — structured list of every decision made, grouped by category, with the reasoning captured
+2. Call out any **Open Risks** — decisions where the user was uncertain, where you see potential issues, or where the answer depends on something you can't verify now
 3. Note **Codebase Findings** — key files, patterns, and constraints discovered during the interview
+4. Flag **Architectural Bets** — decisions that are hard to reverse later, so the spec can call them out explicitly
 
-This summary becomes input to the spec-writing phase.
+This summary becomes the primary input to the spec-writing phase. Every decision here must map to at least one behavior in the spec.
 
 ## Anti-patterns
 
-- Asking yes/no questions when you need specifics
+- Shallow questions — "How should errors be handled?" instead of "When the webhook delivery fails after 3 retries, should we dead-letter it, alert the user, or silently drop? What's the retry backoff strategy?"
 - Asking about things you could have looked up in the code
 - Moving on without confirming understanding
-- Asking all questions in one category before considering cross-category dependencies
-- Not recommending — just presenting options without a suggestion
+- Generic options — "Simple / Medium / Complex" instead of named patterns with trade-offs
+- Not recommending — presenting options without a clear, reasoned opinion
+- Premature closure — wrapping up because you've asked "enough" instead of because the decision tree is fully resolved
+- Surface-level categories — going through Requirements/Architecture/Testing as a checkbox exercise instead of letting the feature's nature drive the depth

--- a/batteries/skills/research/SKILL.md
+++ b/batteries/skills/research/SKILL.md
@@ -1,0 +1,158 @@
+---
+description: "Structured research — outline generation, parallel deep-dive via Explore agents, synthesis into documented findings."
+context: inline
+---
+
+# Research Methodology
+
+You are the research orchestrator. You scope and synthesize, but delegate all deep-dives to agents.
+
+Research follows a pipeline: **Scope → Outline → Deep-Dive → Synthesize → Document**.
+
+The setup phase classifies the research type. This skill drives the work phase — create tasks for each pipeline stage, then execute.
+
+## Phase 1: Scope & Outline
+
+**Create task:** "Define research outline"
+
+Identify what to research based on the classification from setup:
+
+- **Feature research** — what exists in the codebase, what patterns apply, what's been tried
+- **Library/tech evaluation** — candidates to compare, evaluation criteria, integration concerns
+- **Brainstorming** — problem space, constraints, possible approaches
+- **Feasibility study** — requirements, blockers, unknowns, scope estimate
+
+Build the outline:
+
+1. **Items** — the discrete things to research (features, libraries, approaches, components)
+2. **Fields** — what to learn about each item (implementation patterns, trade-offs, compatibility, performance)
+3. **Sources** — where to look (codebase paths, docs, web, git history)
+
+Present the outline to the user for confirmation before proceeding. Use AskUserQuestion if the scope is ambiguous or items need prioritization.
+
+Output: a clear list of N items to deep-dive, with fields to populate for each.
+
+## Phase 2: Deep-Dive (parallel)
+
+**Create one task per item** (or batch if items are small).
+
+For each item, spawn an Explore agent:
+
+```
+Agent(subagent_type="Explore", prompt="
+  Research: {item_name}
+  Fields to populate: {field_list}
+  Sources to check: {source_list}
+  
+  Codebase: Glob/Grep for relevant files, read IN FULL.
+  Search .claude/rules/, docs/, planning/ for constraints and prior art.
+  Git: git log --oneline -20 --grep='{keyword}'
+  Issues: gh issue list --search '{keyword}'
+  Web: WebSearch for docs, comparisons, best practices.
+  
+  Report structured findings:
+  - Summary (2-3 sentences)
+  - Key findings (bullet points with file:line or URL sources)
+  - Fields (populated from outline)
+  - Uncertainties (mark as [uncertain])
+  - Recommendation (if applicable)
+")
+```
+
+### Execution rules
+- Run items in parallel (up to 5 concurrent agents)
+- Each agent works independently — no cross-item dependencies
+- If an item turns out to be trivial, collapse the finding inline
+- If an item reveals sub-items, note them but don't expand scope without user approval
+
+## Phase 3: Synthesize
+
+**Create task:** "Synthesize research findings"
+
+Compile all agent results into a unified analysis:
+
+### Comparison matrix (for evaluations)
+| Item | {Field 1} | {Field 2} | {Field 3} | Verdict |
+|------|-----------|-----------|-----------|---------|
+| A    | ...       | ...       | ...       | ...     |
+
+### Questions answered
+- Q: {question from scope} → A: {answer} (source)
+
+### Key findings
+- {finding with source reference}
+
+### Recommendations
+Rank options. Explain trade-offs. Be opinionated — "we recommend X because Y."
+
+### Open questions
+- {what's still unclear or needs further research}
+
+### Next steps
+- {concrete actions: create spec, prototype, more research, etc.}
+
+Present synthesis to user. Walk through key findings. Get input on recommendations and next steps.
+
+## Phase 4: Document
+
+**Create task:** "Write research doc"
+
+Write persistent findings to `{research_path}/{YYYY-MM-DD}-{slug}.md`:
+
+```markdown
+---
+date: {YYYY-MM-DD}
+topic: {topic}
+type: {feature | library-eval | brainstorm | feasibility}
+status: complete
+github_issue: {N or null}
+items_researched: {N}
+---
+
+# Research: {topic}
+
+## Context
+Why this research was done. Classification from setup.
+
+## Scope
+Items researched, fields evaluated, sources used.
+
+## Findings
+
+### {Item 1}
+{structured findings from deep-dive}
+
+### {Item 2}
+...
+
+## Comparison
+{matrix if applicable}
+
+## Recommendations
+{ranked options with trade-offs}
+
+## Open Questions
+{what's still unclear}
+
+## Next Steps
+{concrete next actions}
+```
+
+## Task Creation Summary
+
+The agent should create tasks in this order:
+
+1. **"Define research outline"** — scope items, fields, sources → present to user
+2. **"Research: {item}"** × N — one per item, each spawns an Explore agent
+3. **"Synthesize findings"** — compile agent results, compare, recommend → present to user
+4. **"Write research doc"** — persist findings to file
+
+## Principles
+
+- **Never deep-dive yourself** — spawn Explore agents for all investigation
+- **Outline before diving** — don't explore without knowing what you're looking for
+- **User confirms scope** — present outline before spawning agents
+- **One agent per item** — parallel, independent, resumable
+- **Source everything** — file:line or URL on every finding
+- **Be opinionated** — recommendations, not just information dumps
+- **Present before documenting** — walk user through findings before writing the doc

--- a/batteries/skills/test-protocol/SKILL.md
+++ b/batteries/skills/test-protocol/SKILL.md
@@ -1,18 +1,25 @@
 ---
-description: "Build + test + retry protocol — Step 1 build check, Step 2 run tests, Step 3 check implementation hints, retry limits (3 attempts)."
+description: "Build + test + retry protocol — build check, run tests, write missing tests via test-agent, retry limits (3 attempts)."
 context: inline
 ---
 
 # Test Protocol
 
-Each TEST sub-phase runs deterministic checks only. Do NOT skip steps or reorder.
+Each TEST phase runs deterministic checks. Do NOT skip steps or reorder.
 
 ## Step 1: Build check
 
 Run the project's **build command** (e.g. `npm run build`), not bare
 `tsc --noEmit`. Projects with build-time codegen (route types, schema
-generation) need the full pipeline. If the build fails, fix and re-run
-before proceeding.
+generation) need the full pipeline. If the build fails, spawn an impl-agent to fix:
+
+```
+Agent(subagent_type="impl-agent", prompt="
+  Build failure. Fix the build error:
+  {error output}
+  After fixing, run: {build_command}
+")
+```
 
 ## Step 2: Run tests
 
@@ -22,12 +29,31 @@ its YAML, verify each one:
 ```
 For each test_case in the spec phase:
   - Does a test exist that covers this case?
-  - If not, write the test BEFORE marking TEST complete.
+  - If not, spawn a test-agent to write it BEFORE marking TEST complete.
   - Run the test and confirm it passes.
 ```
 
-If no test infrastructure exists, check the spec's Verification Strategy
-section for setup instructions.
+For missing tests, spawn a test-agent:
+
+```
+Agent(subagent_type="test-agent", prompt="
+  Write tests for: {behavior description}
+  Test cases to cover: {list from spec}
+  Follow existing test patterns in: {test directory}
+  After writing, run: {test_command}
+")
+```
+
+If tests fail, spawn an impl-agent to fix the implementation (not the tests):
+
+```
+Agent(subagent_type="impl-agent", prompt="
+  Test failure: {test name}
+  Error: {error output}
+  Fix the implementation code, not the test.
+  After fixing, run: {build_command} && {test_command}
+")
+```
 
 ## Step 3: Check for implementation hints
 
@@ -36,9 +62,11 @@ Re-read the spec's Implementation Hints section. Verify:
 - Initialization follows documented patterns
 - Known gotchas addressed
 
+If hints reveal issues, spawn an impl-agent to fix.
+
 ## Retry limits
 
 If a build or test fails:
-- Fix the issue using the error output (not blind retry)
+- Spawn an agent to fix the issue using the error output (not blind retry)
 - Maximum 3 fix attempts per failure before escalating to user
 - Never silence errors, skip tests, or weaken assertions to pass

--- a/batteries/skills/vp-execution/SKILL.md
+++ b/batteries/skills/vp-execution/SKILL.md
@@ -1,15 +1,17 @@
 ---
-description: "Verification plan execution — run VP steps literally, record evidence, report pass/fail."
+description: "Verification plan execution — run VP steps literally, spawn impl-agents for repairs, record evidence."
 context: inline
 ---
 
 # VP Execution
 
+You are the VP orchestrator. You execute verification steps and delegate all code fixes to agents.
+
 ## Your Role
 
 - Execute VP steps literally as written — commands, expected outcomes, all of it
 - Do NOT modify VP steps — they are the source of truth
-- Fix implementation code if VP steps fail (never the VP steps themselves)
+- Spawn impl-agents to fix implementation code when VP steps fail
 - Record all results as evidence and commit it
 
 ## VP Step Execution Protocol
@@ -30,15 +32,26 @@ For each VP step:
 
 ## Repair-Reverify Loop
 
-If any VP step fails:
+If any VP step fails, spawn an impl-agent to fix:
 
-1. **Diagnose** — read the error, identify the root cause in implementation code
-2. **Fix** — make the minimal code change to address the root cause
-3. **Re-run** — re-execute the failed VP step exactly as originally specified
-4. **Max 3 cycles** — if still failing after 3 repair attempts, record as permanently failed
+```
+Agent(subagent_type="impl-agent", prompt="
+  VP step {step_id} failed: {step_title}
+  Command: {command that failed}
+  Expected: {expected outcome}
+  Actual: {actual outcome}
+  Fix the implementation code so this VP step passes.
+  Do NOT modify the VP step itself.
+  After fixing, run: {build_command} && {test_command}
+")
+```
 
-**Critical:** Fix the implementation, never the VP steps. VP steps encode what the feature
-is supposed to do — they are correct by definition.
+After the agent completes:
+1. **Re-run** the failed VP step exactly as originally specified
+2. If still failing, spawn another fix agent with the new error context
+3. **Max 3 cycles** per step — if still failing after 3 repair agents, record as permanently failed
+
+**Critical:** Agents fix the implementation, never the VP steps. VP steps encode what the feature is supposed to do — they are correct by definition.
 
 ## Evidence Recording
 


### PR DESCRIPTION
## Summary
- Update 6 skills with dev1's agent-orchestration versions (code-impl, code-review, debug-methodology, interview, test-protocol, vp-execution)
- Add 2 new generic skills (auto-debug, research)
- Update kata.yaml implementation rules to reference skill invocations

## Test plan
- [x] Build passes
- [x] Tests pass