### PR TITLE
feat: #49 simplify setup — remove batteries distinction

### DIFF
--- a/.kata/kata.yaml
+++ b/.kata/kata.yaml
@@ -1,25 +1,27 @@
 project:
-  name: ''
+  name: kata-wm
+  build_command: npm run build
 spec_path: planning/specs
 research_path: planning/research
 session_retention_days: 7
 task_rules:
-  - Tasks are pre-created by kata enter. Do NOT create new tasks with TaskCreate.
-  - Run TaskList FIRST to discover pre-created tasks and their dependency chains.
-  - Use TaskUpdate to mark tasks in_progress/completed. Never use TaskCreate.
-  - Follow the dependency chain — blocked tasks cannot start until dependencies complete.
+- Tasks are pre-created by kata enter. Do NOT create new tasks with TaskCreate.
+- Run TaskList FIRST to discover pre-created tasks and their dependency chains.
+- Use TaskUpdate to mark tasks in_progress/completed. Never use TaskCreate.
+- "Follow the dependency chain \u2014 blocked tasks cannot start until dependencies\
+  \ complete."
 modes:
   research:
     name: Research
     description: Explore and synthesize findings
     stop_conditions:
-      - tasks_complete
-      - committed
-      - pushed
+    - tasks_complete
+    - committed
+    - pushed
     intent_keywords:
-      - research
-      - explore
-      - learn about
+    - research
+    - explore
+    - learn about
     template: research.md
   planning:
     name: Planning
@@ -27,15 +29,15 @@ modes:
     issue_handling: required
     issue_label: feature
     stop_conditions:
-      - tasks_complete
-      - spec_valid
-      - committed
-      - pushed
+    - tasks_complete
+    - spec_valid
+    - committed
+    - pushed
     intent_keywords:
-      - plan feature
-      - spec
-      - design
-      - write spec
+    - plan feature
+    - spec
+    - design
+    - write spec
     template: planning.md
   implementation:
     name: Implementation
@@ -43,96 +45,97 @@ modes:
     issue_handling: required
     issue_label: feature
     stop_conditions:
-      - tasks_complete
-      - committed
-      - pushed
-      - tests_pass
-      - feature_tests_added
+    - tasks_complete
+    - committed
+    - pushed
+    - tests_pass
+    - feature_tests_added
     intent_keywords:
-      - implement
-      - build
-      - code
-      - develop
-      - execute spec
+    - implement
+    - build
+    - code
+    - develop
+    - execute spec
     template: implementation.md
   task:
     name: Task
     description: Combined planning + implementation for small tasks
     issue_handling: none
     stop_conditions:
-      - tasks_complete
-      - committed
+    - tasks_complete
+    - committed
     intent_keywords:
-      - 'task:'
-      - chore
-      - small task
-      - quick change
-      - cleanup
-      - refactor
+    - 'task:'
+    - chore
+    - small task
+    - quick change
+    - cleanup
+    - refactor
     template: task.md
     workflow_prefix: TK
     aliases:
-      - chore
-      - small
+    - chore
+    - small
   freeform:
     name: Freeform
     description: Quick questions and discussion (no phases)
     stop_conditions: []
     intent_keywords:
-      - question
-      - how does
-      - what is
-      - where is
-      - explain
-      - help me understand
+    - question
+    - how does
+    - what is
+    - where is
+    - explain
+    - help me understand
     template: freeform.md
     workflow_prefix: FF
     aliases:
-      - question
-      - ask
-      - help
-      - qa
+    - question
+    - ask
+    - help
+    - qa
   verify:
     name: Verify
     description: Execute Verification Plan steps
     issue_handling: none
     stop_conditions:
-      - tasks_complete
-      - committed
-      - pushed
+    - tasks_complete
+    - committed
+    - pushed
     intent_keywords:
-      - verify
-      - run verification
-      - execute VP
-      - verification plan
+    - verify
+    - run verification
+    - execute VP
+    - verification plan
     template: verify.md
     workflow_prefix: VF
   debug:
     name: Debug
-    description: Systematic hypothesis-driven debugging with reproduction, root cause analysis, and fix
+    description: Systematic hypothesis-driven debugging with reproduction, root cause
+      analysis, and fix
     issue_handling: none
     stop_conditions:
-      - tasks_complete
-      - committed
-      - pushed
+    - tasks_complete
+    - committed
+    - pushed
     intent_keywords:
-      - debug
-      - investigate
-      - bug
-      - why is
-      - broken
+    - debug
+    - investigate
+    - bug
+    - why is
+    - broken
     template: debug.md
     workflow_prefix: DB
     aliases:
-      - investigate
+    - investigate
   onboard:
     name: Onboard
     description: Configure kata for a new project
     stop_conditions: []
     intent_keywords:
-      - onboard
-      - setup kata
-      - configure kata
-      - initialize kata
+    - onboard
+    - setup kata
+    - configure kata
+    - initialize kata
     template: onboard.md
 kata_version: 0.3.0

--- a/eval/harness.ts
+++ b/eval/harness.ts
@@ -184,19 +184,19 @@ export async function runScenario(
     projectDir = join(EVAL_PROJECTS_DIR, `${scenario.id}-${ts}`)
     mkdirSync(projectDir, { recursive: true })
     cpSync(fixturePath, projectDir, { recursive: true })
-    // Bootstrap kata config + seed batteries templates so fixtures never go stale.
-    // --batteries seeds all mode templates so the agent never needs to run setup itself
+    // Bootstrap kata config + seed templates so fixtures never go stale.
+    // --yes seeds all mode templates so the agent never needs to run setup itself
     // (which would overwrite kata.yaml and lose fixtureSetup customizations).
     const setupEnv = { ...process.env, CLAUDE_PROJECT_DIR: projectDir }
     try {
-      execSync(`kata setup --batteries --cwd="${projectDir}"`, {
+      execSync(`kata setup --yes --cwd="${projectDir}"`, {
         cwd: projectDir,
         env: setupEnv,
         stdio: ['pipe', 'pipe', 'pipe'],
       })
     } catch (err) {
       const msg = (err as { stderr?: Buffer }).stderr?.toString() ?? String(err)
-      throw new Error(`kata setup --batteries failed for fixture '${fixtureName}': ${msg}`)
+      throw new Error(`kata setup --yes failed for fixture '${fixtureName}': ${msg}`)
     }
     // Run optional per-scenario fixture setup commands
     if (scenario.fixtureSetup?.length) {

--- a/eval/scenarios/impl-auth.ts
+++ b/eval/scenarios/impl-auth.ts
@@ -5,7 +5,7 @@
  * This scenario enters implementation mode to execute the spec.
  *
  * Uses the tanstack-start fixture which has:
- * - kata batteries installed
+ * - kata setup --yes installed
  * - Auth research doc at planning/research/RE-395c-0221-auth.md
  * - Approved spec at planning/specs/better-auth-integration.md
  *

--- a/eval/scenarios/impl-review-agents.ts
+++ b/eval/scenarios/impl-review-agents.ts
@@ -34,7 +34,7 @@ export const implReviewAgentsScenario: EvalScenario = {
   templatePath: '.kata/templates/implementation.md',
   fixture: 'tanstack-start',
   fixtureSetup: [
-    // kata batteries --update writes a fresh kata.yaml with reviews commented out.
+    // kata update writes a fresh kata.yaml with reviews commented out.
     // Uncomment the reviews block and set code_review: true + code_reviewers list.
     "sed -i 's/^# reviews:/reviews:/' .kata/kata.yaml",
     "sed -i 's/^#   code_review:.*$/  code_review: true/' .kata/kata.yaml",

--- a/eval/scenarios/planning-auth.ts
+++ b/eval/scenarios/planning-auth.ts
@@ -6,7 +6,7 @@
  * This scenario enters planning mode to spec the feature.
  *
  * Uses the tanstack-start fixture which already has:
- * - kata batteries installed (hooks, templates, spec-templates)
+ * - kata setup --yes installed (hooks, templates, spec-templates)
  * - The auth research doc committed
  * - A local bare remote for git push
  *

--- a/eval/scenarios/planning-review-agents.ts
+++ b/eval/scenarios/planning-review-agents.ts
@@ -30,7 +30,7 @@ export const planningReviewAgentsScenario: EvalScenario = {
   name: 'Planning: review-agent + gemini + codex spawn simultaneously in P3',
   fixture: 'tanstack-start',
   fixtureSetup: [
-    // batteries --update comments out the reviews block; uncomment it and add spec reviewers
+    // kata update comments out the reviews block; uncomment it and add spec reviewers
     "sed -i 's/^# reviews:/reviews:/' .kata/kata.yaml",
     "sed -i '/^reviews:/a\\  spec_review: true' .kata/kata.yaml",
     "sed -i '/^  spec_review: true/a\\  spec_reviewers:' .kata/kata.yaml",

--- a/src/commands/projects/init.ts
+++ b/src/commands/projects/init.ts
@@ -5,7 +5,7 @@ import { isKataEnabled } from '../../manager/discovery.js'
 import { readIndex, writeIndex, addProject as addToIndex } from '../../manager/registry.js'
 
 /**
- * kata projects init <path> [--alias=<name>] [--no-batteries]
+ * kata projects init <path> [--alias=<name>]
  *
  * Initialize a new project at the given path with .kata/ structure,
  * then register it in the manager.
@@ -13,13 +13,10 @@ import { readIndex, writeIndex, addProject as addToIndex } from '../../manager/r
 export async function initProject(args: string[]): Promise<void> {
   let projectPath: string | null = null
   let alias: string | undefined
-  let noBatteries = false
 
   for (const arg of args) {
     if (arg.startsWith('--alias=')) {
       alias = arg.slice('--alias='.length)
-    } else if (arg === '--no-batteries') {
-      noBatteries = true
     } else if (!arg.startsWith('--')) {
       projectPath = arg
     }
@@ -27,7 +24,7 @@ export async function initProject(args: string[]): Promise<void> {
 
   if (!projectPath) {
     // biome-ignore lint/suspicious/noConsole: CLI output
-    console.error('Usage: kata projects init <path> [--alias=<name>] [--no-batteries]')
+    console.error('Usage: kata projects init <path> [--alias=<name>]')
     process.exitCode = 1
     return
   }
@@ -47,7 +44,7 @@ export async function initProject(args: string[]): Promise<void> {
     // biome-ignore lint/suspicious/noConsole: CLI output
     console.error(`Project already has kata config: ${absPath}`)
     // biome-ignore lint/suspicious/noConsole: CLI output
-    console.error('Use `kata batteries --update --cwd=' + absPath + '` to update templates instead.')
+    console.error('Use `kata update --cwd=' + absPath + '` to update templates instead.')
     process.exitCode = 1
     return
   }
@@ -57,12 +54,7 @@ export async function initProject(args: string[]): Promise<void> {
   console.error(`Initializing kata at: ${absPath}`)
 
   const { setup } = await import('../setup.js')
-  const setupArgs = ['--yes', '--batteries', `--cwd=${absPath}`]
-  if (noBatteries) {
-    // Remove --batteries, just do basic setup
-    setupArgs.splice(1, 1)
-  }
-  await setup(setupArgs)
+  await setup(['--yes', `--cwd=${absPath}`])
 
   // Register in manager if initialized
   if (isManagerInitialized()) {
@@ -91,7 +83,6 @@ export async function initProject(args: string[]): Promise<void> {
         action: 'initialized',
         path: absPath,
         alias: alias || absPath.split('/').pop(),
-        batteries: !noBatteries,
       },
       null,
       2,

--- a/src/commands/scaffold-batteries.ts
+++ b/src/commands/scaffold-batteries.ts
@@ -1,5 +1,5 @@
 // scaffold-batteries.ts — copy batteries-included content to a project
-// Called by `kata setup --batteries` after base setup completes.
+// Called by `kata setup --yes` after base setup completes.
 import { copyFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { dirname } from 'node:path'

--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
-import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import * as os from 'node:os'
 import jsYaml from 'js-yaml'
@@ -59,7 +59,7 @@ describe('setup --yes', () => {
     expect(output).toContain('kata setup complete')
 
     // Check kata.yaml was created
-    const kataYamlPath = join(tmpDir, '.claude', 'workflows', 'kata.yaml')
+    const kataYamlPath = join(tmpDir, '.kata', 'kata.yaml')
     expect(existsSync(kataYamlPath)).toBe(true)
 
     // Parse and verify kata.yaml content
@@ -70,7 +70,7 @@ describe('setup --yes', () => {
     expect(config.research_path).toBe('planning/research')
 
     // Check sessions directory was created
-    expect(existsSync(join(tmpDir, '.claude', 'sessions'))).toBe(true)
+    expect(existsSync(join(tmpDir, '.kata', 'sessions'))).toBe(true)
   })
 
   it('creates settings.json with 3 default hooks', async () => {
@@ -106,7 +106,7 @@ describe('setup --yes', () => {
     // First setup
     await captureSetup(['--yes'], tmpDir)
 
-    const kataYamlPath = join(tmpDir, '.claude', 'workflows', 'kata.yaml')
+    const kataYamlPath = join(tmpDir, '.kata', 'kata.yaml')
     const firstContent = readFileSync(kataYamlPath, 'utf-8')
 
     // Second setup
@@ -185,7 +185,12 @@ describe('setup --yes', () => {
 
     const output = await captureSetup(['--yes'], tmpDir)
     expect(output).toContain('my-detected-project')
-    expect(output).toContain('vitest run')
+
+    // test_command should be saved in kata.yaml config
+    const kataYamlPath = join(tmpDir, '.kata', 'kata.yaml')
+    const config = jsYaml.load(readFileSync(kataYamlPath, 'utf-8')) as Record<string, unknown>
+    const project = config.project as Record<string, unknown>
+    expect(project.test_command).toBe('vitest run')
   })
 
   it('auto-detects CI config', async () => {
@@ -193,7 +198,49 @@ describe('setup --yes', () => {
     writeFileSync(join(tmpDir, '.github', 'workflows', 'ci.yml'), 'name: CI')
 
     const output = await captureSetup(['--yes'], tmpDir)
-    expect(output).toContain('github-actions')
+    expect(output).toContain('kata setup complete')
+
+    // CI should be saved in kata.yaml config
+    const kataYamlPath = join(tmpDir, '.kata', 'kata.yaml')
+    const config = jsYaml.load(readFileSync(kataYamlPath, 'utf-8')) as Record<string, unknown>
+    const project = config.project as Record<string, unknown>
+    expect(project.ci).toBe('github-actions')
+  })
+
+  it('setup --yes scaffolds mode templates, spec-templates, and github templates', async () => {
+    const output = await captureSetup(['--yes'], tmpDir)
+    expect(output).toContain('kata setup complete')
+
+    // Mode templates should exist in .kata/templates/
+    const templatesDir = join(tmpDir, '.kata', 'templates')
+    expect(existsSync(templatesDir)).toBe(true)
+    const templateFiles = readdirSync(templatesDir) as string[]
+    expect(templateFiles.length).toBeGreaterThan(0)
+
+    // Spec templates should exist in planning/spec-templates/
+    const specTemplatesDir = join(tmpDir, 'planning', 'spec-templates')
+    expect(existsSync(specTemplatesDir)).toBe(true)
+    const specFiles = readdirSync(specTemplatesDir) as string[]
+    expect(specFiles.length).toBeGreaterThan(0)
+
+    // GitHub issue templates should exist in .github/ISSUE_TEMPLATE/
+    const issueTemplateDir = join(tmpDir, '.github', 'ISSUE_TEMPLATE')
+    expect(existsSync(issueTemplateDir)).toBe(true)
+    const issueFiles = readdirSync(issueTemplateDir) as string[]
+    expect(issueFiles.length).toBeGreaterThan(0)
+  })
+
+  it('setup --yes is idempotent with batteries content', async () => {
+    // First setup
+    await captureSetup(['--yes'], tmpDir)
+
+    // Second setup should not error
+    const output = await captureSetup(['--yes'], tmpDir)
+    expect(output).toContain('kata setup complete')
+
+    // Templates should still exist
+    const templatesDir = join(tmpDir, '.kata', 'templates')
+    expect(existsSync(templatesDir)).toBe(true)
   })
 })
 

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -2,7 +2,7 @@
 // For the guided setup interview, use: kata enter onboard
 // Hook registration uses 'kata hook <name>' commands in .claude/settings.json.
 import { execSync } from 'node:child_process'
-import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import jsYaml from 'js-yaml'
 import { getDefaultProfile, type SetupProfile } from '../config/setup-profile.js'
@@ -15,8 +15,9 @@ type WmConfig = Record<string, unknown> & {
   reviews?: { spec_review?: boolean; code_review?: boolean; code_reviewer?: string | null }
   wm_version?: string
 }
-import { getPackageRoot, findProjectDir, getSessionsDir, getProjectTemplatesDir, getProjectSkillsDir } from '../session/lookup.js'
+import { getPackageRoot, findProjectDir, getSessionsDir, getProjectTemplatesDir } from '../session/lookup.js'
 import { getKataConfigPath, loadKataConfig } from '../config/kata-config.js'
+import { scaffoldBatteries } from './scaffold-batteries.js'
 
 /**
  * Resolve the absolute path to the kata binary.
@@ -358,45 +359,6 @@ function applySetup(cwd: string, profile: SetupProfile, explicitCwd: boolean): v
     }
   }
 
-  // Copy interview configs from batteries
-  const batteriesInterviewsDir = join(getPackageRoot(), 'batteries', 'interviews')
-  const projectInterviewsDir = join(projectRoot, '.kata', 'interviews')
-  if (existsSync(batteriesInterviewsDir)) {
-    mkdirSync(projectInterviewsDir, { recursive: true })
-    for (const f of readdirSync(batteriesInterviewsDir)) {
-      if (f.endsWith('.yaml')) {
-        const dest = join(projectInterviewsDir, f)
-        if (!existsSync(dest)) {
-          copyFileSync(join(batteriesInterviewsDir, f), dest)
-        }
-      }
-    }
-  }
-
-  // Copy steps.yaml from batteries (shared step definitions for $ref)
-  const stepsYamlSrc = join(getPackageRoot(), 'batteries', 'steps.yaml')
-  const stepsYamlDest = join(projectRoot, '.kata', 'steps.yaml')
-  if (existsSync(stepsYamlSrc) && !existsSync(stepsYamlDest)) {
-    copyFileSync(stepsYamlSrc, stepsYamlDest)
-  }
-
-  // Copy skills from batteries (two-level: skills/<name>/SKILL.md)
-  const skillsSrc = join(getPackageRoot(), 'batteries', 'skills')
-  if (existsSync(skillsSrc)) {
-    const skillsDest = getProjectSkillsDir(projectRoot)
-    for (const entry of readdirSync(skillsSrc, { withFileTypes: true })) {
-      if (!entry.isDirectory()) continue
-      const skillSrcDir = join(skillsSrc, entry.name)
-      const skillDestDir = join(skillsDest, entry.name)
-      mkdirSync(skillDestDir, { recursive: true })
-      for (const f of readdirSync(skillSrcDir)) {
-        const src = join(skillSrcDir, f)
-        const dest = join(skillDestDir, f)
-        copyFileSync(src, dest)
-      }
-    }
-  }
-
   // Register hooks in settings.json using absolute kata binary path
   // If kata_binary is set in kata.yaml, use it (for A/B testing branches)
   let binaryOverride: string | undefined
@@ -413,7 +375,7 @@ function applySetup(cwd: string, profile: SetupProfile, explicitCwd: boolean): v
 }
 
 /**
- * kata setup [--yes] [--strict] [--batteries] [--cwd=PATH]
+ * kata setup [--yes] [--strict] [--cwd=PATH]
  *
  * Pure configuration — writes kata.yaml, registers hooks, scaffolds content.
  * Always flag-driven; never enters an interactive session.
@@ -433,53 +395,25 @@ export async function setup(args: string[]): Promise<void> {
   profile.strict = parsed.strict
 
   if (parsed.yes) {
-    // --yes / --batteries: write everything with auto-detected defaults
+    // --yes: write everything with auto-detected defaults
     applySetup(parsed.cwd, profile, parsed.explicitCwd)
 
-    // --batteries: scaffold full mode templates, skills, and spec templates
+    // Deprecation notice for --batteries flag
     if (parsed.batteries) {
-      const { scaffoldBatteries } = await import('./scaffold-batteries.js')
-      const result = scaffoldBatteries(projectRoot)
-
-      process.stdout.write('kata setup --batteries complete:\n')
-      process.stdout.write(`  Project: ${profile.project_name}\n`)
-      process.stdout.write(`  Config: .kata/kata.yaml\n`)
-      process.stdout.write(`  Hooks: .claude/settings.json\n`)
-      process.stdout.write('\nBatteries scaffolded:\n')
-      if (result.templates.length > 0) {
-        process.stdout.write(`  Mode templates (${result.templates.length}):\n`)
-        for (const t of result.templates) {
-          process.stdout.write(`    .kata/templates/${t}\n`)
-        }
-      }
-      if (result.specTemplates.length > 0) {
-        process.stdout.write(`  Spec templates (${result.specTemplates.length}):\n`)
-        for (const s of result.specTemplates) {
-          process.stdout.write(`    planning/spec-templates/${s}\n`)
-        }
-      }
-      if (result.skills.length > 0) {
-        process.stdout.write(`  Skills (${result.skills.length}):\n`)
-        for (const s of result.skills) {
-          process.stdout.write(`    .claude/skills/${s}\n`)
-        }
-      }
-      if (result.skipped.length > 0) {
-        process.stdout.write(`  Skipped (already exist): ${result.skipped.join(', ')}\n`)
-      }
-    } else {
-      // Plain --yes summary
-      process.stdout.write('kata setup complete:\n')
-      process.stdout.write(`  Project: ${profile.project_name}\n`)
-      process.stdout.write(`  Test command: ${profile.test_command ?? 'none detected'}\n`)
-      process.stdout.write(`  CI: ${profile.ci ?? 'none detected'}\n`)
-      process.stdout.write(`  Config: .kata/kata.yaml\n`)
-      process.stdout.write(`  Hooks: .claude/settings.json\n`)
-      process.stdout.write(`    - SessionStart\n`)
-      process.stdout.write(`    - UserPromptSubmit\n`)
-      process.stdout.write(`    - Stop\n`)
-      process.stdout.write(`    - PreToolUse (consolidated: mode-gate + task-deps + gates + evidence)\n`)
+      process.stderr.write('Note: --batteries is deprecated. kata setup --yes now includes all content.\n')
     }
+
+    // Always scaffold batteries content (templates, skills, spec templates, etc.)
+    const result = scaffoldBatteries(projectRoot)
+
+    // Unified output summary
+    process.stdout.write('kata setup complete:\n')
+    process.stdout.write(`  Project: ${profile.project_name}\n`)
+    process.stdout.write(`  Config: .kata/kata.yaml\n`)
+    process.stdout.write(`  Hooks: .claude/settings.json\n`)
+    process.stdout.write(`  Templates: ${result.templates.length} mode templates\n`)
+    process.stdout.write(`  Spec templates: ${result.specTemplates.length}\n`)
+    process.stdout.write(`  Skills: ${result.skills.length}\n`)
 
     process.stdout.write('\nOptional: add shorthand to package.json scripts:\n')
     process.stdout.write('  "kata": "kata"\n')
@@ -493,15 +427,11 @@ export async function setup(args: string[]): Promise<void> {
 
 Usage:
   kata setup --yes                Quick setup with auto-detected defaults
-  kata setup --yes --strict       Setup + PreToolUse task enforcement hooks
-  kata setup --batteries          Setup + scaffold batteries-included starter content
-  kata setup --batteries --strict Setup + batteries + strict hooks
+  kata setup --yes --strict       Setup + strict PreToolUse task enforcement hooks
 
 Flags:
-  --yes         Write config and register hooks using auto-detected defaults
-  --batteries   Scaffold mode templates, skills, spec templates, and GitHub issue templates
-                (implies --yes)
-  --strict      Also register PreToolUse hooks: task-deps, task-evidence
+  --yes         Write config, register hooks, scaffold templates and skills
+  --strict      Also register PreToolUse hooks for task enforcement
   --cwd=PATH    Run setup in a different directory
 
 For the guided setup interview, run:

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -348,7 +348,7 @@ function applySetup(cwd: string, profile: SetupProfile, explicitCwd: boolean): v
   // Ensure sessions directory exists
   mkdirSync(getSessionsDir(projectRoot), { recursive: true })
 
-  // Seed onboard.md so `kata enter onboard` works without --batteries
+  // Seed onboard.md (lives in system templates/, not batteries/)
   const templatesDir = getProjectTemplatesDir(projectRoot)
   const onboardDest = join(templatesDir, 'onboard.md')
   if (!existsSync(onboardDest)) {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -28,12 +28,9 @@ export async function update(args: string[]): Promise<void> {
   const config = loadKataConfig(projectRoot)
   const installedVersion = config.kata_version
 
-  if (installedVersion === currentVersion) {
-    process.stdout.write(`Already up to date (v${currentVersion})\n`)
-    return
+  if (installedVersion !== currentVersion) {
+    process.stdout.write(`Updating from v${installedVersion ?? 'unknown'} to v${currentVersion}\n`)
   }
-
-  process.stdout.write(`Updating from v${installedVersion ?? 'unknown'} to v${currentVersion}\n`)
 
   let updated = 0
   let skipped = 0
@@ -76,5 +73,9 @@ export async function update(args: string[]): Promise<void> {
     writeFileSync(kataYamlPath, jsYaml.dump(yaml, { lineWidth: 120, noRefs: true }))
   }
 
-  process.stdout.write(`\nUpdate complete: ${updated} updated, ${skipped} skipped\n`)
+  if (updated === 0 && skipped === 0) {
+    process.stdout.write('All templates up to date\n')
+  } else {
+    process.stdout.write(`\nUpdate complete: ${updated} updated, ${skipped} skipped\n`)
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,7 +255,7 @@ Usage:
   kata register-mode <template-path> [options]   Register existing template as mode
   kata suggest <message>                         Detect mode from message, output guidance
   kata doctor [--fix] [--json]                   Diagnose and fix session state
-  kata setup [--yes] [--strict] [--batteries]    Setup kata in a project
+  kata setup [--yes] [--strict]                   Setup kata in a project
   kata update                                      Update templates to latest package version
   kata migrate [--dry-run]                         Convert old-format templates to gate/hint format
   kata config [--show]                            Show resolved config with provenance
@@ -280,10 +280,8 @@ Hook Dispatch:
   kata hook stop-conditions       Check exit conditions (Stop)
 
 Setup:
-  kata setup --yes                Quick setup with auto-detected defaults
+  kata setup --yes                Quick setup (config, hooks, templates, skills)
   kata setup --yes --strict       Setup with PreToolUse gate hooks
-  kata setup --batteries          Setup + scaffold batteries-included starter content (implies --yes)
-  kata setup --batteries --strict Setup + batteries + strict PreToolUse hooks
   kata enter onboard                Guided setup interview (interactive, agent-driven)
   kata update                     Update templates + stamp kata_version
   kata migrate                    Convert old-format templates to new gate/hint format

--- a/src/session/lookup.ts
+++ b/src/session/lookup.ts
@@ -260,7 +260,7 @@ export function resolveTemplatePath(templatePath: string): string {
   throw new Error(
     `Template not found: ${templatePath}\n` +
       `Checked:\n${checked.map((p) => `  - ${p}`).join('\n')}\n` +
-      `Run 'kata setup --batteries' to seed project templates.`,
+      `Run 'kata setup --yes' to seed project templates.`,
   )
 }
 
@@ -290,6 +290,6 @@ export function resolveSpecTemplatePath(name: string): string {
   throw new Error(
     `Spec template not found: ${name}\n` +
       `Checked:\n${checked.map((p) => `  - ${p}`).join('\n')}\n` +
-      `Run 'kata setup --batteries' to seed spec templates.`,
+      `Run 'kata setup --yes' to seed spec templates.`,
   )
 }


### PR DESCRIPTION
## Summary
- **P2.1**: Merge batteries into unified `--yes` path — `kata setup --yes` now scaffolds all content (templates, skills, spec-templates, prompts, GitHub templates). `--batteries` flag deprecated with stderr notice.
- **P2.2**: Fix `kata update` to always diff template content regardless of version match (removes early return bug).
- **P2.3**: Clean up all `--batteries` references across init.ts, lookup.ts, index.ts help text, and eval scenario comments.
- **P2.4**: Update eval harness to use `kata setup --yes` instead of `kata setup --batteries`.

Closes #49

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (1/1)
- [x] `bun test src/commands/setup.test.ts` passes (11/11, 37 assertions)
- [x] Setup tests verify unified output, batteries scaffolding, and idempotency
- [ ] Manual: `kata setup --yes --cwd=/tmp/test` scaffolds full content
- [ ] Manual: `kata setup --batteries --cwd=/tmp/test` shows deprecation notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)